### PR TITLE
perf: optimize the prompt information text

### DIFF
--- a/src/submit/submit.py
+++ b/src/submit/submit.py
@@ -65,7 +65,7 @@ def _cut_code(
         elif start_match is None and end_match is not None:
             click.secho(f"源文件 {file.name} 中存在 NEGATIVE 模式的终止注释，但未找到对应的起始注释！", fg="red", err=True)
         else:
-            click.secho(f"警告：源文件 {file.name} 中未找到预期的 NEGATIVE 模式的注释，将不裁剪任何代码！", fg="yellow", err=True)
+            pass
 
     if positive:
         start_match = re.search(rf"{POSITIVE_COMMENT_BEGIN}", code, flags=re_flags)
@@ -214,8 +214,11 @@ def copy_directory(
         if resolved_exclude_dirs and dirpath in resolved_exclude_dirs:
             click.secho(f"已排除目录：{dirpath.absolute()}", fg="magenta")
             continue
-        if txt_dir in dirpath.parents or dirpath == txt_dir:  # 如果当前目录是目标目录或其子目录，则跳过
-            click.secho(f"已跳过目录：{dirpath.absolute()}，跳过原因：输出目录与输入目录是同一目录，或输出目录在输入目录内", fg="magenta")
+        if txt_dir in dirpath.parents:  # 如果当前目录在指定输出 TXT 的目录内，则跳过
+            click.secho(f"已跳过目录：{dirpath.absolute()}，跳过原因：当前目录在指定输出 TXT 的目录内", fg="magenta")
+            continue
+        if dirpath == txt_dir:  # 如果当前目录与指定输出 TXT 的目录是同一目录，则跳过
+            click.secho(f"已跳过目录：{dirpath.absolute()}，跳过原因：当前目录与指定输出 TXT 的目录是同一目录", fg="magenta")
             continue
         for file in filenames:
             fileabspath = dirpath / file
@@ -232,7 +235,7 @@ def copy_directory(
                 )
 
     if not copy_file_tasks:
-        click.secho("未找到需要处理的 .sas 文件")
+        click.secho("未找到需要处理的 .sas 文件", fg="yellow")
         return
 
     if merge:  # 合并文件

--- a/src/submit/submit.py
+++ b/src/submit/submit.py
@@ -65,7 +65,7 @@ def _cut_code(
         elif start_match is None and end_match is not None:
             click.secho(f"源文件 {file.name} 中存在 NEGATIVE 模式的终止注释，但未找到对应的起始注释！", fg="red", err=True)
         else:
-            click.secho(f"警告：源文件 {file.name} 中未找到预期的 NEGATIVE 模式的注释！", fg="yellow", err=True)
+            click.secho(f"警告：源文件 {file.name} 中未找到预期的 NEGATIVE 模式的注释，将不裁剪任何代码！", fg="yellow", err=True)
 
     if positive:
         start_match = re.search(rf"{POSITIVE_COMMENT_BEGIN}", code, flags=re_flags)
@@ -78,7 +78,7 @@ def _cut_code(
         elif start_match is None and end_match is not None:
             click.secho(f"源文件 {file.name} 中存在 POSITIVE 模式的终止注释，但未找到对应的起始注释！", fg="red", err=True)
         else:
-            click.secho(f"警告：源文件 {file.name} 中未找到预期的 POSITIVE 模式的注释！", fg="yellow", err=True)
+            click.secho(f"警告：源文件 {file.name} 中未找到预期的 POSITIVE 模式的注释，将不裁剪任何代码！", fg="yellow", err=True)
 
     # 替换宏变量
     if substitute:
@@ -220,7 +220,7 @@ def copy_directory(
         for file in filenames:
             fileabspath = dirpath / file
             if resolved_exclude_files and fileabspath in resolved_exclude_files:
-                click.secho(f"已排除文件：{fileabspath.absolute()}", fg="yellow")
+                click.secho(f"已排除文件：{fileabspath.absolute()}", fg="magenta")
                 continue
             if file.endswith(".sas"):
                 dirrelpath = dirpath.relative_to(sas_dir)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -30,7 +30,6 @@ def test_cutcode_incomplete_comment(dummy_sas_dir: Path, tmp_path: Path) -> None
     assert "存在 NEGATIVE 模式的起始注释，但未找到对应的终止注释" in result.stderr
     assert "存在 NEGATIVE 模式的终止注释，但未找到对应的起始注释" in result.stderr
     assert "未找到预期的 POSITIVE 模式的注释" in result.stderr
-    assert "未找到预期的 NEGATIVE 模式的注释" in result.stderr
 
 
 def test_copyfile(dummy_sas_dir: Path, tmp_path: Path) -> None:
@@ -256,8 +255,8 @@ def test_copydir_no_files_need_process(dummy_sas_dir: Path, tmp_path: Path) -> N
     assert "未找到需要处理的 .sas 文件" in result.stdout
 
 
-def test_copydir_output_dir_inside_input_dir(dummy_sas_dir: Path, tmp_path: Path) -> None:
-    """测试 copydir 命令，输出目录在输入目录内"""
+def test_copydir_output_dir_equal_input_dir(dummy_sas_dir: Path, tmp_path: Path) -> None:
+    """测试 copydir 命令，输出目录与输入目录是同一目录"""
 
     runner = CliRunner()
 
@@ -276,4 +275,28 @@ def test_copydir_output_dir_inside_input_dir(dummy_sas_dir: Path, tmp_path: Path
 
     assert result.exit_code == 0
 
-    assert "输出目录与输入目录是同一目录，或输出目录在输入目录内" in result.stdout
+    assert "当前目录与指定输出 TXT 的目录是同一目录" in result.stdout
+
+
+def test_copydir_output_dir_inside_input_dir(dummy_sas_dir: Path, tmp_path: Path) -> None:
+    """测试 copydir 命令，输出目录在输入目录内"""
+
+    runner = CliRunner()
+
+    sas_dir = dummy_sas_dir / "sponser_only"
+    txt_dir = dummy_sas_dir
+
+    result = runner.invoke(
+        cli,
+        [
+            "copydir",
+            "-s",
+            str(sas_dir),
+            "-t",
+            str(txt_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    assert "当前目录在指定输出 TXT 的目录内" in result.stdout


### PR DESCRIPTION
程序假设 `.sas` 文件中至少存在 `positive` 模式的注释，如果没有 `positive` 模式的注释，则发出警告。

对于宏程序，通常既不会有 `positive` 模式的注释，也不会有 `negative` 模式的注释，程序必然会发出警告。

针对宏程序应当在 `positive` 模式注释缺失时，不发出警告的现实需求，可增加 `--allow-positive-missing` 选项，这将在下一个 PR 中实现。